### PR TITLE
Updating patch version of tiny-slider

### DIFF
--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -62,7 +62,7 @@
     "stylelint-junit-formatter": "0.2.2",
     "stylelint-webpack-plugin": "2.4.0",
     "terser-webpack-plugin": "4.2.3",
-    "tiny-slider": "2.9.2",
+    "tiny-slider": "2.9.4",
     "webpack": "4.38.0",
     "webpackbar": "3.2.0"
   },


### PR DESCRIPTION
Hey there,
In our Plugin we've been working on, we encountered an issue with Tiny Slider and Responsive Containers.
As the items in our slider are of variable size, it causes tiny-slider to add whitespaces at the end of the items.

### 1. Why is this change necessary?
Tiny Slider Version 2.9.2 has a known issue with responsive containers.

### 2. What does this change do, exactly?
Fix known issues, by updating the patch version of tiny-slider.

### 3. Describe each step to reproduce the issue or behaviour.
Create a tiny slider instance, with variable sizes of the image items and the outer container. Set controls to true and skip through a bunch of items.

### 4. Please link to the relevant issues (if any).
ganlanyuan/tiny-slider#387
Fixed in version 2.9.3 https://github.com/ganlanyuan/tiny-slider/releases/tag/v2.9.3

### 5. Checklist

- [N] I have written tests and verified that they fail without my change
- [N] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [N] I have written or adjusted the documentation according to my changes
- [N] This change has comments for package types, values, functions, and non-obvious lines of code
- [Y] I have read the contribution requirements and fulfil them.
